### PR TITLE
Allow adding youtube channels by channelid

### DIFF
--- a/ExternalAPIs.Tests/YoutubeClientShould.cs
+++ b/ExternalAPIs.Tests/YoutubeClientShould.cs
@@ -35,18 +35,18 @@ namespace ExternalAPIs.Tests
         }
 
         [Fact, Trait("Category", "LocalOnly")]
-        public async Task GetChannelIdFromChannelName()
+        public async Task GetChannelIdFromUsername()
         {
             const string channelName = "LoLChampSeries";
-            var channelId = await sut.GetChannelIdFromChannelName(channelName);
-            
+            var channelId = await sut.GetChannelIdFromUsername(channelName);
+
             Assert.NotNull(channelId);
         }
 
         [Fact, Trait("Category", "LocalOnly")]
         public async Task GetLiveVideos()
         {
-            // channelId of the value returned by the test "GetChannelIdFromChannelName"
+            // channelId of the value returned by the test "GetChannelIdFromUsername"
             const string channelId = "UCvqRdlKsE5Q8mf8YXbdIJLw";
             var onlineVideos = await sut.GetLivestreamVideos(channelId);
 

--- a/ExternalAPIs/Youtube/Dto/QueryRoot/GetChannelIdByNameRoot.cs
+++ b/ExternalAPIs/Youtube/Dto/QueryRoot/GetChannelIdByNameRoot.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace ExternalAPIs.Youtube.Dto.QueryRoot

--- a/ExternalAPIs/Youtube/IYoutubeReadonlyClient.cs
+++ b/ExternalAPIs/Youtube/IYoutubeReadonlyClient.cs
@@ -7,13 +7,12 @@ namespace ExternalAPIs.Youtube
     public interface IYoutubeReadonlyClient
     {
         /// <summary> A channel in youtube can have multiple livestreams running at one time </summary>
-        /// <param name="channelId">A channel id discovered from querying <see cref="GetChannelIdFromChannelName"/></param>
-        /// <param name="cancellationToken"></param>
-        /// <returns></returns>
         Task<SearchLiveVideosRoot> GetLivestreamVideos(string channelId, CancellationToken cancellationToken = default(CancellationToken));
 
-        Task<string> GetChannelIdFromChannelName(string channelName, CancellationToken cancellationToken = default(CancellationToken));
+        /// <summary> Discover the channel id given a username </summary>
+        Task<string> GetChannelIdFromUsername(string userName, CancellationToken cancellationToken = default(CancellationToken));
 
+        /// <summary> Get the details for a youtube videoid </summary>
         Task<VideoRoot> GetLivestreamDetails(string videoId, CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/ExternalAPIs/Youtube/RequestConstants.cs
+++ b/ExternalAPIs/Youtube/RequestConstants.cs
@@ -7,6 +7,6 @@
         public const string VideoLivestreamDetails = GoogleApiRoot + @"videos?part=LiveStreamingDetails&key=" + API_KEY;
         public const string VideoSnippet = GoogleApiRoot + @"videos?part=Snippet&key=" + API_KEY;
         public const string SearchChannelLiveVideos = GoogleApiRoot + @"search?type=video&eventType=live&part=snippet,id&channelId={0}&key=" + API_KEY;
-        public const string GetChannelIdByName = GoogleApiRoot + @"channels?forUsername={0}&part=id&key=" + API_KEY;
+        public const string GetChannelIdByUsername = GoogleApiRoot + @"channels?forUsername={0}&part=id&key=" + API_KEY;
     }
 }

--- a/ExternalAPIs/Youtube/YoutubeReadonlyClient.cs
+++ b/ExternalAPIs/Youtube/YoutubeReadonlyClient.cs
@@ -20,15 +20,15 @@ namespace ExternalAPIs.Youtube
             return searchChannelLiveVideos;
         }
 
-        public async Task<string> GetChannelIdFromChannelName(string channelName, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<string> GetChannelIdFromUsername(string userName, CancellationToken cancellationToken = default(CancellationToken))
         {
-            if (IsNullOrWhiteSpace(channelName))
-                throw new ArgumentException("Argument is null or whitespace", nameof(channelName));
+            if (IsNullOrWhiteSpace(userName))
+                throw new ArgumentException("Argument is null or whitespace", nameof(userName));
 
-            var request = RequestConstants.GetChannelIdByName.Replace("{0}", channelName);
+            var request = RequestConstants.GetChannelIdByUsername.Replace("{0}", userName);
             var channelDetails = await HttpClientExtensions.ExecuteRequest<GetChannelIdByNameRoot>(request, cancellationToken);
             if (channelDetails.Items == null || channelDetails.Items.Count == 0)
-                throw new HttpRequestWithStatusException(HttpStatusCode.BadRequest, "Channel name not found " + channelName);
+                throw new HttpRequestWithStatusException(HttpStatusCode.BadRequest, "No channel found for username" + userName);
 
             return channelDetails.Items?.FirstOrDefault()?.Id;
         }

--- a/GlobalAssemblyInfo.cs
+++ b/GlobalAssemblyInfo.cs
@@ -22,5 +22,5 @@
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[assembly: AssemblyVersion("2.11.0.0")]
-[assembly: AssemblyFileVersion("2.11.0.0")]
+[assembly: AssemblyVersion("2.11.1.0")]
+[assembly: AssemblyFileVersion("2.11.1.0")]

--- a/Livestream.Monitor/Model/ApiClients/LivestreamQueryResult.cs
+++ b/Livestream.Monitor/Model/ApiClients/LivestreamQueryResult.cs
@@ -20,5 +20,10 @@ namespace Livestream.Monitor.Model.ApiClients
         public bool IsSuccess => FailedQueryException == null;
 
         public FailedQueryException FailedQueryException { get; set; }
+
+        public override string ToString()
+        {
+            return $"{ChannelIdentifier} - IsSuccess: {IsSuccess}";
+        }
     }
 }


### PR DESCRIPTION
Fix bug with only showing the first offline youtube channel in the livestream datagrid

Should address #35 . Would result in failure to add channels if their username happened to start with UC/HC, if this is the case the channel can still be added from the channel id instead.