### PR TITLE
Fix missing popups for new livestreams

### DIFF
--- a/GlobalAssemblyInfo.cs
+++ b/GlobalAssemblyInfo.cs
@@ -22,5 +22,5 @@
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[assembly: AssemblyVersion("2.11.2.0")]
-[assembly: AssemblyFileVersion("2.11.2.0")]
+[assembly: AssemblyVersion("2.11.3.0")]
+[assembly: AssemblyFileVersion("2.11.3.0")]

--- a/Livestream.Monitor/Model/ApiClients/YoutubeApiClient.cs
+++ b/Livestream.Monitor/Model/ApiClients/YoutubeApiClient.cs
@@ -151,7 +151,7 @@ namespace Livestream.Monitor.Model.ApiClients
                     // video ids are only returned for online streams, we need to show something to the user
                     // so create a placeholder livestream model object for the offline channel.
                     // TODO - query the channel to get their display name information rather than using the actual channel name
-                    if (!videoIds.Any())
+                    if (!livestreamModels.Any())
                     {
                         queryResults.Add(new LivestreamQueryResult(channelIdentifier)
                         {
@@ -210,6 +210,12 @@ namespace Livestream.Monitor.Model.ApiClients
                     catch (HttpRequestWithStatusException ex) when (ex.StatusCode == HttpStatusCode.ServiceUnavailable)
                     {
                         await Task.Delay(2000, cancellationToken);
+                    }
+                    catch (HttpRequestWithStatusException)
+                    {
+                        // can happen in the case of the video being removed
+                        // the youtube api will report the videoid as live but looking up the videoid will fail with BadRequest
+                        break;
                     }
                     retryCount++;
                 }

--- a/Livestream.Monitor/Model/Monitoring/MonitorStreamsModel.cs
+++ b/Livestream.Monitor/Model/Monitoring/MonitorStreamsModel.cs
@@ -234,8 +234,16 @@ namespace Livestream.Monitor.Model.Monitoring
             var newStreams = livestreamModels.Except(Livestreams).ToList();
             var removedStreams = Livestreams.Except(livestreamModels).ToList();
 
-            Livestreams.AddRange(newStreams);
-            Livestreams.RemoveRange(removedStreams);
+            // add/remove streams one at a time so we trigger regular add/remove collection change event
+            // using addrange/removerange will instead trigger a reset event and will not state what new items were added/removed
+            foreach (var livestreamModel in newStreams)
+            {
+                Livestreams.Add(livestreamModel);
+            }
+            foreach (var livestreamModel in removedStreams)
+            {
+                Livestreams.Remove(livestreamModel);
+            }
         }
 
         private void AddChannels(params ChannelIdentifier[] newChannels)


### PR DESCRIPTION
Addresses #40 

Due to addrange/removerange triggering reset events without populating what was added or removed, we have to go back to using an iterator and adding/removing each stream 1 at a time.

Fixed a bug where youtube streams would be removed from the list due to having no online videos, also handled a side case where a video was deleted just after the youtube api reported it as live.

Removed retries in twitch client when the api succesfully returns no live streams. This may need to be reverted if the api is still flakey as it was when that change for retries was first implemented.